### PR TITLE
Message history + channel display 

### DIFF
--- a/NewCode/chat-app/app/Http/Controllers/PrivateMessagesController.php
+++ b/NewCode/chat-app/app/Http/Controllers/PrivateMessagesController.php
@@ -26,6 +26,21 @@ class PrivateMessagesController extends Controller
 
     public function broadcast(Request $request)
     {
+        $conversation_id = 1;
+
+        $validated = $request->validate([
+            'message' => 'required|string',
+            //'conversation_id' => 'required|exists:conversations,id',
+        ]);
+
+        // Save the message in the database
+        $message = Message::create([
+            'user_id' => Auth::id(),  // Get the authenticated user's ID
+            //'conversation_id' => $validated['conversation_id'],
+            'conversation_id' => $conversation_id,
+            'content' => $validated['message'],
+        ]);
+
         broadcast(new MessageBroadcast($request->get('message')))->toOthers();
         return view('message.broadcast', ['message' =>$request->get('message')]);
     }

--- a/NewCode/chat-app/app/Http/Controllers/ServerController.php
+++ b/NewCode/chat-app/app/Http/Controllers/ServerController.php
@@ -3,12 +3,20 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Channel;
+
 
 class ServerController extends Controller
 {
     public function index()
     {
-        // Your logic here
-        return view('server');
+        $channels = Channel::all(); // Fetch all channels
+        return view('server', compact('channels'));
+    }
+
+    public function showChannel($channelId)
+    {
+        $channel = Channel::findOrFail($channelId);
+        return view('channel', compact('channel'));
     }
 }

--- a/NewCode/chat-app/app/Models/Message.php
+++ b/NewCode/chat-app/app/Models/Message.php
@@ -9,7 +9,7 @@ class Message extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'channel_id', 'content'];
+    protected $fillable = ['user_id', 'conversation_id', 'content'];
 
     public function user()
     {

--- a/NewCode/chat-app/resources/views/layouts/navigation.blade.php
+++ b/NewCode/chat-app/resources/views/layouts/navigation.blade.php
@@ -1,4 +1,4 @@
-<nav x-data="{ open: false }" class="bg-white border-r border-gray-100 fixed inset-y-0 left-0 w-64 h-screen overflow-y-auto">
+<nav x-data="{ showChannels: {{ request()->is('server*') ? 'true' : 'false' }} }" class="bg-white border-r border-gray-100 fixed inset-y-0 left-0 w-64 h-screen overflow-y-auto">
     <div class="flex flex-col bg-gray-800 text-white h-full">
         <!-- Logo -->
         <div class="flex p-4">
@@ -10,12 +10,29 @@
         <!-- Navigation Links -->
         <div class="flex flex-col justify-between">
             <div class="space-y-2">
-                <!-- Server Link -->
-                <x-nav-link :href="route('server')" :active="request()->routeIs('server')" class="block p-4 hover:bg-white-700 focus:outline-none">
+                <!-- Server Link with Dropdown -->
+                <button 
+                    @click="showChannels = !showChannels; window.location.href = '{{ route('server') }}'"
+                    class="block w-full text-left p-4 hover:bg-gray-700 focus:outline-none"
+                >
                     {{ __('Server') }}
-                </x-nav-link>
+                </button>
+
+                <!-- Channels List (Visible only on /server) -->
+                @if(isset($channels) && count($channels) > 0)
+                <div x-show="showChannels" class="block pl-6 space-y-2">
+                    @foreach($channels as $channel)
+                    <div class="block">
+                        <x-nav-link :href="route('server.channel', $channel->id)" class="block p-2 text-white hover:bg-gray-700 w-full focus:outline-none">
+                            {{ $channel->name }}
+                        </x-nav-link>
+                    </div>  
+                    @endforeach
+                </div>
+                @endif
+
                 <!-- Private Messages Link -->
-                <x-nav-link :href="route('chatify')" :active="request()->routeIs('chatify')" class="block p-4 hover:bg-white-700 focus:outline-none">
+                <x-nav-link :href="route('chatify')" :active="request()->routeIs('chatify')" class="block p-4 hover:bg-gray-700 focus:outline-none">
                     {{ __('Private Messages') }}
                 </x-nav-link>
             </div>

--- a/NewCode/chat-app/resources/views/private-messages.blade.php
+++ b/NewCode/chat-app/resources/views/private-messages.blade.php
@@ -54,7 +54,9 @@
   //Broadcast messages
   $("form").submit(function (event) {
     event.preventDefault();
-
+    
+    let conversation_id = 1;
+    
     $.ajax({
       url:     "/broadcast",
       method:  'POST',

--- a/NewCode/chat-app/routes/web.php
+++ b/NewCode/chat-app/routes/web.php
@@ -46,7 +46,7 @@ Route::middleware(['auth', 'admin'])->group(function () {
 
 // Server route
 Route::get('/server', [ServerController::class, 'index'])->name('server');
-
+Route::get('/server/{channel}', [ServerController::class, 'showChannel'])->name('server.channel');
 
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Message now get saved to the db for group messaging. At the moment the conversation_id is hardcoded until the backend for creating channels is done. That way, when we go to a channel it will take note of it  and save the message under that id. 

After clicking on server, we can display all channels available. These are hardcoded but there will a button to add channel and once created they will display in the side menu. 

Issues: #30 #54 

Please do the following in the mysql for saving message and channel. 

SELECT * FROM DB_NAME.channels;
INSERT INTO DB_NAME.channels (name,description, created_at, updated_at) 
VALUES
('Project', 'project chat', NOW(), NOW()),
('Social', 'social chat', NOW(), NOW());

SELECT * FROM DB_NAME.conversations;
INSERT INTO DB_NAME.conversations (id) 
VALUES
(1);
