### PR TITLE
Channel display UI  and creating channels

### DIFF
--- a/NewCode/chat-app/app/Http/Controllers/ChannelController.php
+++ b/NewCode/chat-app/app/Http/Controllers/ChannelController.php
@@ -9,7 +9,7 @@ class ChannelController extends Controller
 {
     public function index()
     {
-        $channels = Channel::all();
+        $channels = Channel::where('type', 'group')->get();
         return view('channels.index', compact('channels'));
     }
 
@@ -18,19 +18,24 @@ class ChannelController extends Controller
         return view('channels.create');
     }
 
+    public function showCreateForm()
+    {
+        return view('create-channel');
+    }
+
     public function store(Request $request)
     {
         $request->validate([
             'name' => 'required|string|unique:channels',
-            'description' => 'nullable|string',
         ]);
 
         Channel::create([
             'name' => $request->name,
             'description' => $request->description,
+            'type' => 'group',
         ]);
 
-        return redirect()->route('channels.index')->with('success', 'Channel created successfully!');
+        return redirect()->route('server')->with('success', 'Channel created successfully!');
     }
 
     public function destroy(Channel $channel)

--- a/NewCode/chat-app/app/Models/Channel.php
+++ b/NewCode/chat-app/app/Models/Channel.php
@@ -9,7 +9,8 @@ class Channel extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'description'];
+    protected $table = 'conversations';
+    protected $fillable = ['name', 'type'];
 
     public function messages()
     {

--- a/NewCode/chat-app/resources/views/create-channel.blade.php
+++ b/NewCode/chat-app/resources/views/create-channel.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="flex-grow p-6 ml-64">
+    <h2 class="text-2xl font-bold mb-4">Create New Channel</h2>
+
+    <form method="POST" action="{{ route('server.create-channel') }}">
+        @csrf
+        
+        <div class="mb-4">
+            <label for="channel-name" class="block text-sm font-medium text-gray-700">Channel Name</label>
+            <input type="text" id="channel-name" name="name" class="mt-1 block w-full p-2 border border-gray-300 rounded-md" required>
+        </div>
+
+        
+        <div class="flex justify-end">
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-700">Create Channel</button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/NewCode/chat-app/resources/views/layouts/navigation.blade.php
+++ b/NewCode/chat-app/resources/views/layouts/navigation.blade.php
@@ -22,17 +22,23 @@
                 @if(isset($channels) && count($channels) > 0)
                 <div x-show="showChannels" class="block pl-6 space-y-2">
                     @foreach($channels as $channel)
-                    <div class="block">
+                    <div class="block hover:text-white">
                         <x-nav-link :href="route('server.channel', $channel->id)" class="block p-2 text-white hover:bg-gray-700 w-full focus:outline-none">
                             {{ $channel->name }}
                         </x-nav-link>
                     </div>  
                     @endforeach
+                 <!-- Button to navigate to create channel page -->
+                 <a href="{{ route('showCreateForm') }}" class="block p-4 text-white text-center rounded-md hover:bg-gray-700 focus:outline-none"">
+                    Create Channel
+                </a>
                 </div>
                 @endif
 
+               
+
                 <!-- Private Messages Link -->
-                <x-nav-link :href="route('chatify')" :active="request()->routeIs('chatify')" class="block p-4 hover:bg-gray-700 focus:outline-none">
+                <x-nav-link :href="route('chatify')" :active="request()->routeIs('chatify')" class="block p-4 text-white text-center rounded-md hover:bg-gray-700 focus:outline-none">
                     {{ __('Private Messages') }}
                 </x-nav-link>
             </div>

--- a/NewCode/chat-app/routes/web.php
+++ b/NewCode/chat-app/routes/web.php
@@ -46,7 +46,11 @@ Route::middleware(['auth', 'admin'])->group(function () {
 
 // Server route
 Route::get('/server', [ServerController::class, 'index'])->name('server');
-Route::get('/server/{channel}', [ServerController::class, 'showChannel'])->name('server.channel');
 
+//create channel routes
+Route::get('/server/create-channel', [ChannelController::class, 'showCreateForm'])->name('showCreateForm');
+Route::post('/server/create-channel', [ChannelController::class, 'store'])->name('server.create-channel');
+
+Route::get('/server/{channel}', [ServerController::class, 'showChannel'])->name('server.channel');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Updated code to save channels (name, id) to conversations table (used for both private and group messaging) where now channels have name, id and a type (private or group). 
Issue: #94 

Added channel display to UI after clicking to server page. You can also create a channel which brings you to a new page where you can enter name and press 'create button'. After pressing, it brings you back to /server where the new channel is displayed. 

Issues: #54 and part of #63 , #64 (delete part still need to be completed)